### PR TITLE
APPS 2653: Update Constraints for searchReferralAgencies

### DIFF
--- a/src/containers/location/LocationsReducer.js
+++ b/src/containers/location/LocationsReducer.js
@@ -55,6 +55,7 @@ const {
   SELECTED_REFERRAL_AGENCY,
   TYPE_OF_CARE,
   ZIP,
+  ZIP_SEARCHED,
 } = PROVIDERS;
 
 const INITIAL_STATE :Map = fromJS({
@@ -92,6 +93,7 @@ const INITIAL_STATE :Map = fromJS({
   [SELECTED_REFERRAL_AGENCY]: null,
   [TYPE_OF_CARE]: [],
   [ZIP]: ['', {}],
+  [ZIP_SEARCHED]: false,
 });
 
 const locationsReducer = (state :Map = INITIAL_STATE, action :Object) => {
@@ -171,10 +173,12 @@ const locationsReducer = (state :Map = INITIAL_STATE, action :Object) => {
       return searchReferralAgencies.reducer(state, action, {
         REQUEST: () => state
           .set(REFERRAL_AGENCY_LOCATIONS, Map())
+          .set(ZIP_SEARCHED, false)
           .setIn([SEARCH_REFERRAL_AGENCIES, REQUEST_STATE], RequestStates.PENDING)
           .setIn([SEARCH_REFERRAL_AGENCIES, action.id], action),
         SUCCESS: () => state
           .set(REFERRAL_AGENCY_LOCATIONS, action.value.referralAgencyLocations)
+          .set(ZIP_SEARCHED, action.value.zipCodeSearched)
           .setIn([SEARCH_REFERRAL_AGENCIES, REQUEST_STATE], RequestStates.SUCCESS),
         FAILURE: () => state.setIn([SEARCH_REFERRAL_AGENCIES, REQUEST_STATE], RequestStates.FAILURE),
         FINALLY: () => state.deleteIn([SEARCH_REFERRAL_AGENCIES, action.id])

--- a/src/containers/location/LocationsReducer.js
+++ b/src/containers/location/LocationsReducer.js
@@ -178,7 +178,7 @@ const locationsReducer = (state :Map = INITIAL_STATE, action :Object) => {
           .setIn([SEARCH_REFERRAL_AGENCIES, action.id], action),
         SUCCESS: () => state
           .set(REFERRAL_AGENCY_LOCATIONS, action.value.referralAgencyLocations)
-          .set(ZIP_SEARCHED, action.value.zipCodeSearched)
+          .set(ZIP_SEARCHED, action.value.zoneSearched)
           .setIn([SEARCH_REFERRAL_AGENCIES, REQUEST_STATE], RequestStates.SUCCESS),
         FAILURE: () => state.setIn([SEARCH_REFERRAL_AGENCIES, REQUEST_STATE], RequestStates.FAILURE),
         FINALLY: () => state.deleteIn([SEARCH_REFERRAL_AGENCIES, action.id])

--- a/src/containers/location/providers/LocationsContainer.js
+++ b/src/containers/location/providers/LocationsContainer.js
@@ -3,7 +3,7 @@
 import React, { useEffect } from 'react';
 
 import styled from 'styled-components';
-import { get, List, Map } from 'immutable';
+import { List, Map, get } from 'immutable';
 import {
   Colors,
   PaginationToolbar,
@@ -38,6 +38,7 @@ import {
   GEOCODE_PLACE,
   LOAD_CURRENT_POSITION,
   SEARCH_LOCATIONS,
+  SEARCH_REFERRAL_AGENCIES,
   loadCurrentPosition,
   searchLocations,
   searchReferralAgencies,
@@ -109,6 +110,9 @@ const LocationsContainer = () => {
   const searchLocationsRS = useSelector((store) => store.getIn(
     [LOCATIONS, SEARCH_LOCATIONS, REQUEST_STATE]
   ));
+  const searchReferralAgenciesRS = useSelector((store) => store.getIn(
+    [LOCATIONS, SEARCH_REFERRAL_AGENCIES, REQUEST_STATE]
+  ));
   const selectedProvider = useSelector((store) => store.getIn([LOCATIONS, SELECTED_PROVIDER]));
   const selectedReferralAgency = useSelector((store) => store.getIn([LOCATIONS, SELECTED_REFERRAL_AGENCY]));
   const searchResults = useSelector((store) => store.getIn([LOCATIONS, HITS], List()));
@@ -139,7 +143,12 @@ const LocationsContainer = () => {
   const lon = get(selectedOption, LON);
 
   const hasSearched = !isStandby(searchLocationsRS);
-  const isLoading = isPending(reduceRequestStates([geocodePlaceRS, searchLocationsRS, loadCurrentPositionRS]));
+  const isLoading = isPending(reduceRequestStates([
+    geocodePlaceRS,
+    searchLocationsRS,
+    loadCurrentPositionRS,
+    searchReferralAgenciesRS
+  ]));
   const geoSearchFailed = isFailure(loadCurrentPositionRS);
 
   useEffect(() => {
@@ -153,6 +162,8 @@ const LocationsContainer = () => {
     }
   }, [
     dispatch,
+    lat,
+    lon,
     searchLocationsRS,
     searchResults,
     selectedOption

--- a/src/containers/location/providers/NoResults.js
+++ b/src/containers/location/providers/NoResults.js
@@ -29,7 +29,8 @@ const {
   LAT,
   LON,
   REFERRAL_AGENCY_LOCATIONS,
-  SELECTED_OPTION
+  SELECTED_OPTION,
+  ZIP_SEARCHED
 } = PROVIDERS;
 
 const { getEntityKeyId, getPropertyValue } = DataUtils;
@@ -38,7 +39,11 @@ const NoResults = () => {
   const dispatch = useDispatch();
   const getText = useSelector(getTextFnFromState);
   const nearbyReferralAgencies = useSelector((store) => store.getIn([LOCATIONS, REFERRAL_AGENCY_LOCATIONS], Map()));
+  const zipCodeWasSearched :?boolean = useSelector((store) => store.getIn([LOCATIONS, ZIP_SEARCHED], false));
   const selectedOption = useSelector((store) => store.getIn([LOCATIONS, SELECTED_OPTION]));
+  const instructionTextObject = zipCodeWasSearched
+    ? NO_RESULTS.DETAILS_WITH_ZIP
+    : NO_RESULTS.DETAILS_WITHOUT_ZIP;
 
   const renderRR = (rr :Map) => {
     const name = getPropertyValue(rr, [PROPERTY_TYPES.FACILITY_NAME, 0]);
@@ -63,7 +68,7 @@ const NoResults = () => {
     <Centered>
       <FontAwesomeIcon size="3x" icon={faSearchLocation} />
       <Instructions color="textSecondary" variant="subtitle1">
-        {getText(NO_RESULTS.DETAILS)}
+        {getText(instructionTextObject)}
       </Instructions>
       {nearbyReferralAgencies.valueSeq().map(renderRR)}
     </Centered>

--- a/src/containers/location/providers/NoResults.js
+++ b/src/containers/location/providers/NoResults.js
@@ -5,7 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { faSearchLocation } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { get, Map } from 'immutable';
+import { Map, get } from 'immutable';
 import { Button, Typography } from 'lattice-ui-kit';
 import { DataUtils } from 'lattice-utils';
 import { useDispatch, useSelector } from 'react-redux';
@@ -13,8 +13,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getTextFnFromState } from '../../../utils/AppUtils';
 import { getDistanceBetweenCoords } from '../../../utils/DataUtils';
 import { PROPERTY_TYPES } from '../../../utils/constants/DataModelConstants';
-import { NO_RESULTS } from '../../../utils/constants/labels';
 import { PROVIDERS, STATE } from '../../../utils/constants/StateConstants';
+import { NO_RESULTS } from '../../../utils/constants/labels';
 import { getCoordinates } from '../../map/MapUtils';
 import { Centered, Row } from '../../styled';
 import { selectReferralAgency } from '../LocationsActions';
@@ -41,9 +41,6 @@ const NoResults = () => {
   const nearbyReferralAgencies = useSelector((store) => store.getIn([LOCATIONS, REFERRAL_AGENCY_LOCATIONS], Map()));
   const zipCodeWasSearched :?boolean = useSelector((store) => store.getIn([LOCATIONS, ZIP_SEARCHED], false));
   const selectedOption = useSelector((store) => store.getIn([LOCATIONS, SELECTED_OPTION]));
-  const instructionTextObject = zipCodeWasSearched
-    ? NO_RESULTS.DETAILS_WITH_ZIP
-    : NO_RESULTS.DETAILS_WITHOUT_ZIP;
 
   const renderRR = (rr :Map) => {
     const name = getPropertyValue(rr, [PROPERTY_TYPES.FACILITY_NAME, 0]);
@@ -68,9 +65,12 @@ const NoResults = () => {
     <Centered>
       <FontAwesomeIcon size="3x" icon={faSearchLocation} />
       <Instructions color="textSecondary" variant="subtitle1">
-        {getText(instructionTextObject)}
+        {getText(NO_RESULTS.DETAILS)}
       </Instructions>
       {nearbyReferralAgencies.valueSeq().map(renderRR)}
+      <Instructions color="textSecondary" variant="subtitle1">
+        {!zipCodeWasSearched && getText(NO_RESULTS.DETAILS_WITHOUT_ZIP)}
+      </Instructions>
     </Centered>
   );
 };

--- a/src/utils/constants/DataModelConstants.js
+++ b/src/utils/constants/DataModelConstants.js
@@ -44,6 +44,7 @@ export const PROPERTY_TYPES = {
   VACANCIES: 'ecps.vacancies',
   VACANCY_LAST_UPDATED: 'ecps.vacancy_last_updated',
   ZIP: 'ecps.facility_zip',
+  ZIP_SERVED: 'ecps.facility_zip_code_served',
 
   PHONE: 'ecps.facility_phone',
 

--- a/src/utils/constants/DataModelConstants.js
+++ b/src/utils/constants/DataModelConstants.js
@@ -44,7 +44,7 @@ export const PROPERTY_TYPES = {
   VACANCIES: 'ecps.vacancies',
   VACANCY_LAST_UPDATED: 'ecps.vacancy_last_updated',
   ZIP: 'ecps.facility_zip',
-  ZIP_SERVED: 'ecps.facility_zip_code_served',
+  ZIP_SERVED: 'ecps.facility_zip_served',
 
   PHONE: 'ecps.facility_phone',
 

--- a/src/utils/constants/PropertyTypes.js
+++ b/src/utils/constants/PropertyTypes.js
@@ -180,6 +180,21 @@ export default [
     indexType: 'BTREE'
   },
   {
+    id: 'ac34130c-1efd-48ec-8b85-12c099090818',
+    type: {
+      namespace: 'ecps',
+      name: 'facility_zip_served'
+    },
+    title: 'Facility Zip Code Served',
+    description: 'Facility Zip Code Served',
+    schemas: [],
+    datatype: 'Int64',
+    pii: false,
+    multiValued: true,
+    analyzer: 'STANDARD',
+    indexType: 'BTREE'
+  },
+  {
     id: '29c1e895-3fbd-47c8-8bd5-33b5c71987e7',
     type: {
       namespace: 'ecps',

--- a/src/utils/constants/StateConstants.js
+++ b/src/utils/constants/StateConstants.js
@@ -34,6 +34,7 @@ export const PROVIDERS = {
   SELECTED_REFERRAL_AGENCY: 'selectedReferralAgency',
   LAT: 'lat',
   LON: 'lon',
+  ZIP_SEARCHED: 'zipCodeSearched',
 
   IS_EDITING_FILTERS: 'isEditingFilters',
   FILTER_PAGE: 'filterPage',

--- a/src/utils/constants/labels/NoResults.js
+++ b/src/utils/constants/labels/NoResults.js
@@ -5,10 +5,20 @@
 import { en, es } from './Languages';
 
 export const NO_RESULTS :Object = {
-  DETAILS: {
+  DETAILS_WITH_ZIP: {
     [en]: 'We couldn’t find any childcare facilities within these search parameters. Please refine your search or '
     + 'contact your local Resource & Referral agency:',
     [es]: 'No pudimos encontrar ninguna guardería dentro de estos parámetros de búsqueda. Refine su búsqueda o '
     + 'comuníquese con su agencia local de Recursos y Referencias:'
+  },
+  DETAILS_WITHOUT_ZIP: {
+    [en]: 'We couldn’t find any childcare facilities within these search parameters. Please refine your search or '
+    + 'contact your local Resource & Referral agency. Listed below are referral agencies based on their physical '
+    + 'distance from the location you searched. To yeild more accurate results for agencies serving your area, '
+    + 'include your zip code in your search.',
+    [es]: 'No pudimos encontrar ninguna guardería dentro de estos parámetros de búsqueda. Refine su búsqueda o '
+    + 'comuníquese con su agencia local de Recursos y Referencias. A continuación se enumeran las agencias de '
+    + 'referencia según su distancia física desde la ubicación que buscó. Para obtener resultados más precisos '
+    + 'para las agencias que prestan servicios en su área, incluya su código postal en su búsqueda.'
   },
 };

--- a/src/utils/constants/labels/NoResults.js
+++ b/src/utils/constants/labels/NoResults.js
@@ -5,20 +5,14 @@
 import { en, es } from './Languages';
 
 export const NO_RESULTS :Object = {
-  DETAILS_WITH_ZIP: {
+  DETAILS: {
     [en]: 'We couldn’t find any childcare facilities within these search parameters. Please refine your search or '
-    + 'contact your local Resource & Referral agency:',
+    + 'contact one of the following Resource & Referral agencies near you:',
     [es]: 'No pudimos encontrar ninguna guardería dentro de estos parámetros de búsqueda. Refine su búsqueda o '
-    + 'comuníquese con su agencia local de Recursos y Referencias:'
+    + 'comuníquese con una de las siguientes agencias de recursos y referencias cercanas a usted:'
   },
   DETAILS_WITHOUT_ZIP: {
-    [en]: 'We couldn’t find any childcare facilities within these search parameters. Please refine your search or '
-    + 'contact your local Resource & Referral agency. Listed below are referral agencies based on their physical '
-    + 'distance from the location you searched. To yeild more accurate results for agencies serving your area, '
-    + 'include your zip code in your search.',
-    [es]: 'No pudimos encontrar ninguna guardería dentro de estos parámetros de búsqueda. Refine su búsqueda o '
-    + 'comuníquese con su agencia local de Recursos y Referencias. A continuación se enumeran las agencias de '
-    + 'referencia según su distancia física desde la ubicación que buscó. Para obtener resultados más precisos '
-    + 'para las agencias que prestan servicios en su área, incluya su código postal en su búsqueda.'
+    [en]: 'For agencies that serve a different location, please include a zip code in your search.',
+    [es]: 'Para las agencias que prestan servicios en una ubicación diferente, incluya un código postal en su búsqueda.'
   },
 };


### PR DESCRIPTION
If a search location comes back with no provider results, we display referral agencies based on their location. If a zip code is present on the searched location, we will use that as a constraint. If there is no zip code present, we will use the latitude and longitude to determine the five closest referral agencies. In both scenarios, agencies will be sorted by distance from the searched location. 

If a zip code is not included in the search, the 'No Results' text will include an additional sentence that encourages the user to include a zip code for more accurate results. 

![Screen Shot 2020-12-15 at 5 35 56 PM](https://user-images.githubusercontent.com/19995069/102294852-fea87400-3efe-11eb-8371-d49c6a591d18.png)